### PR TITLE
Stop polling if max messages reached

### DIFF
--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -16,9 +16,8 @@ module Pheme
       }.merge(poller_configuration || {})
 
       queue_poller.before_request do |stats|
-        max_messages_reached = max_messages && stats.received_message_count >= max_messages
-        throw :stop_polling if max_messages_reached
-      end
+        throw :stop_polling if stats.received_message_count >= max_messages
+      end  if max_messages
     end
 
     def poll

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -1,18 +1,23 @@
 module Pheme
   class QueuePoller
-    attr_accessor :queue_url, :queue_poller, :connection_pool_block, :format, :poller_configuration
+    attr_accessor :queue_url, :queue_poller, :connection_pool_block, :format, :max_messages, :poller_configuration
 
-    def initialize(queue_url:, connection_pool_block: false, format: :json, poller_configuration: {})
+    def initialize(queue_url:, connection_pool_block: false, max_messages: nil, format: :json, poller_configuration: {})
       raise ArgumentError, "must specify non-nil queue_url" unless queue_url.present?
       @queue_url = queue_url
       @queue_poller = Aws::SQS::QueuePoller.new(queue_url)
       @connection_pool_block = connection_pool_block
       @format = format
+      @max_messages = max_messages
       @poller_configuration = {
         wait_time_seconds: 10, # amount of time a long polling receive call can wait for a mesage before receiving a empty response (which will trigger another polling request)
         idle_timeout: 20, # disconnects poller after 20 seconds of idle time
         skip_delete: true, # manually delete messages
       }.merge(poller_configuration || {})
+
+      queue_poller.before_request do |stats|
+        throw :stop_polling if max_messages_reached?
+      end
     end
 
     def poll
@@ -61,6 +66,10 @@ module Pheme
     end
 
   private
+
+    def max_messages_reached?
+      max_messages && stats.received_message_count >= max_messages
+    end
 
     def with_optional_connection_pool_block(&blk)
       if connection_pool_block

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -15,9 +15,11 @@ module Pheme
         skip_delete: true, # manually delete messages
       }.merge(poller_configuration || {})
 
-      queue_poller.before_request do |stats|
-        throw :stop_polling if stats.received_message_count >= max_messages
-      end  if max_messages
+      if max_messages
+        queue_poller.before_request do |stats|
+          throw :stop_polling if stats.received_message_count >= max_messages
+        end
+      end
     end
 
     def poll

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -16,7 +16,8 @@ module Pheme
       }.merge(poller_configuration || {})
 
       queue_poller.before_request do |stats|
-        throw :stop_polling if max_messages_reached?
+        max_messages_reached = max_messages && stats.received_message_count >= max_messages
+        throw :stop_polling if max_messages_reached
       end
     end
 
@@ -66,10 +67,6 @@ module Pheme
     end
 
   private
-
-    def max_messages_reached?
-      max_messages && stats.received_message_count >= max_messages
-    end
 
     def with_optional_connection_pool_block(&blk)
       if connection_pool_block

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -4,6 +4,7 @@ describe Pheme::QueuePoller do
     poller = double
     allow(poller).to receive(:poll).with(kind_of(Hash))
     allow(poller).to receive(:parse_message)
+    allow(poller).to receive(:before_request)
     poller
   end
   before(:each) do
@@ -21,6 +22,12 @@ describe Pheme::QueuePoller do
     context "when initialized with a nil queue_url" do
       it "raises an ArgumentError" do
         expect { ExampleQueuePoller.new(queue_url: nil) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when initialized with max_messages" do
+      it "should set max_messages" do
+        expect(ExampleQueuePoller.new(queue_url: "queue_url", max_messages: 5).max_messages).to eq(5)
       end
     end
   end


### PR DESCRIPTION
The pheme poller now accepts another parameter that tells the poller how many messages to read before it stops.

Reference docs: http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/QueuePoller.html