### PR TITLE
Make recursive-open-struct dependency version less restrictive

### DIFF
--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/pheme.gemspec
+++ b/pheme.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "aws-sdk", "~> 2"
   gem.add_dependency "activesupport", ">= 4"
-  gem.add_dependency "recursive-open-struct", "~> 1"
+  gem.add_dependency "recursive-open-struct", ">= 0.5.0"
   gem.add_dependency "smarter_csv", "~> 1"
 
   gem.add_development_dependency "rspec", "~> 3.4"


### PR DESCRIPTION
Some other gems we use have `recursive-open-struct` version `0.5` as a dependency.