### PR TITLE
Support for publishing Strings

### DIFF
--- a/lib/pheme/topic_publisher.rb
+++ b/lib/pheme/topic_publisher.rb
@@ -13,7 +13,12 @@ module Pheme
 
     def publish(message)
       Pheme.log(:info, "Publishing to #{topic_arn}: #{message}")
-      Pheme.configuration.sns_client.publish(topic_arn: topic_arn, message: message.to_json)
+      Pheme.configuration.sns_client.publish(topic_arn: topic_arn, message: serialize(message))
+    end
+
+    def serialize(message)
+      return message if message.is_a? String
+      message.to_json
     end
   end
 end

--- a/spec/topic_publisher_spec.rb
+++ b/spec/topic_publisher_spec.rb
@@ -29,5 +29,20 @@ describe Pheme::TopicPublisher do
       })
       subject.publish_events
     end
+
+    context 'with string message' do
+      let(:topic_arn) { "arn:aws:sns:anything" }
+      let(:message) { "don't touch my string" }
+
+      subject {Pheme::TopicPublisher.new(topic_arn: topic_arn)}
+
+      it "publishes unchanged message" do
+        expect(Pheme.configuration.sns_client).to receive(:publish).with({
+                                                                           topic_arn: topic_arn,
+                                                                           message: message,
+                                                                         })
+        subject.publish(message)
+      end
+    end
   end
 end


### PR DESCRIPTION
In case you already have the payload you want to send in `String` form, it's handy to be able to send your message unchanged.

In my specific use case: I receive a JSON record already serialized as a String and I'd like to publish that. Currently I have to deserialize that object, just so that Pheme can serialized it internally.