### PR TITLE
Relax aws-sdk dependency to v3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,15 @@
 machine:
   ruby:
-    version: 2.2.2
+    version: 2.4.2
 dependencies:
   override:
     - 'rvm-exec 2.2.2 bundle install'
-    - 'rvm-exec 2.3.0 bundle install'
+    - 'rvm-exec 2.3.5 bundle install'
+    - 'rvm-exec 2.4.2 bundle install'
   post:
     - bundle exec bundle-audit update && bundle exec bundle-audit check
 test:
   override:
     - 'rvm-exec 2.2.2 bundle exec rspec'
-    - 'rvm-exec 2.3.0 bundle exec rspec'
+    - 'rvm-exec 2.3.5 bundle exec rspec'
+    - 'rvm-exec 2.4.2 bundle exec rspec'

--- a/pheme.gemspec
+++ b/pheme.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ["MIT"]
   gem.required_ruby_version = ">= 2.1.0"
 
-  gem.add_dependency "aws-sdk", "~> 2"
+  gem.add_dependency "aws-sdk", ">= 2", "< 4"
   gem.add_dependency "activesupport", ">= 4"
   gem.add_dependency "recursive-open-struct", "~> 1"
   gem.add_dependency "smarter_csv", "~> 1"


### PR DESCRIPTION
This is a less elegant solution than https://github.com/wealthsimple/pheme/pull/13 but unblocks the ability to use v3.