### PR TITLE
Do not track SIGTERM in Rollbar.

### DIFF
--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -30,6 +30,8 @@ module Pheme
           begin
             handle(data)
             queue_poller.delete_message(message)
+          rescue SignalException => e
+            throw :stop_polling
           rescue => e
             Pheme.log(:error, "Exception: #{e.inspect}")
             Pheme.log(:error, e.backtrace.join("\n"))


### PR DESCRIPTION
Every time we deploy apps that have long pollers an exception is tracked in Rollbar, for example https://rollbar.com/wealthsimple/tooth-fairy/items/227/

This plans to address the issue by simply telling AWS SDK to stop polling it.