### PR TITLE
Support custom SQS client

### DIFF
--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -2,10 +2,10 @@ module Pheme
   class QueuePoller
     attr_accessor :queue_url, :queue_poller, :connection_pool_block, :format, :max_messages, :poller_configuration
 
-    def initialize(queue_url:, connection_pool_block: false, max_messages: nil, format: :json, poller_configuration: {})
+    def initialize(queue_url:, connection_pool_block: false, max_messages: nil, format: :json, poller_configuration: {}, sqs_client: nil)
       raise ArgumentError, "must specify non-nil queue_url" unless queue_url.present?
       @queue_url = queue_url
-      @queue_poller = Aws::SQS::QueuePoller.new(queue_url)
+      @queue_poller = Aws::SQS::QueuePoller.new(queue_url, client: sqs_client)
       @connection_pool_block = connection_pool_block
       @messages_processed = 0
       @messages_received = 0

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = "0.0.11".freeze
+  VERSION = "0.0.12".freeze
 end

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -19,6 +19,15 @@ describe Pheme::QueuePoller do
         expect(ExampleQueuePoller.new(queue_url: "queue_url", max_messages: 5).max_messages).to eq(5)
       end
     end
+
+    context "when initialized with sqs_client" do
+      let(:sqs_client) { Object.new }
+
+      it "should set custom sqs_client" do
+        expect(Aws::SQS::QueuePoller).to receive(:new).with("queue_url", client: sqs_client)
+        ExampleQueuePoller.new(queue_url: "queue_url", sqs_client: sqs_client)
+      end
+    end
   end
 
   let(:poller) { ExampleQueuePoller.new(queue_url: queue_url, format: format) }


### PR DESCRIPTION
Our use case for this is a project that needs to talk to SQS queues across different AWS accounts.
This PR allows you provide an instance of `Aws::SQS::Client` to each `QueuePoller`, thus allowing you to communicate with as many AWS accounts you need.