### PR TITLE
Pass timestamp down to handler

### DIFF
--- a/lib/pheme/message_handler.rb
+++ b/lib/pheme/message_handler.rb
@@ -2,7 +2,7 @@ module Pheme
   class MessageHandler
     attr_reader :message, :timestamp
 
-    def initialize(message:, timestamp:)
+    def initialize(message:, metadata:)
       @message = message
     end
 

--- a/lib/pheme/message_handler.rb
+++ b/lib/pheme/message_handler.rb
@@ -1,8 +1,8 @@
 module Pheme
   class MessageHandler
-    attr_reader :message
+    attr_reader :message, :timestamp
 
-    def initialize(message:)
+    def initialize(message:, timestamp:)
       @message = message
     end
 

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -32,7 +32,8 @@ module Pheme
           Pheme.logger.tagged(queue_message.message_id) do
             begin
               content = parse_body(queue_message)
-              handle(content)
+              timestamp = parse_timestamp(queue_message)
+              handle(content, timestamp)
               queue_poller.delete_message(queue_message)
               log_delete(queue_message)
               @messages_processed += 1
@@ -73,6 +74,11 @@ module Pheme
       parsed_content
     end
 
+    def parse_timestamp(queue_message)
+      message_body = JSON.parse(queue_message.body)
+      message_body['Timestamp']
+    end
+
     def get_metadata(message_body)
       message_body.except('Message', 'Records')
     end
@@ -91,7 +97,7 @@ module Pheme
       RecursiveOpenStruct.new({ wrapper: parsed_body }, recurse_over_arrays: true).wrapper
     end
 
-    def handle(_message)
+    def handle(_message, _timestamp)
       raise NotImplementedError
     end
 

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -32,8 +32,8 @@ module Pheme
           Pheme.logger.tagged(queue_message.message_id) do
             begin
               content = parse_body(queue_message)
-              timestamp = parse_timestamp(queue_message)
-              handle(content, timestamp)
+              metadata = parse_metadata(queue_message)
+              handle(content, metadata)
               queue_poller.delete_message(queue_message)
               log_delete(queue_message)
               @messages_processed += 1
@@ -74,9 +74,9 @@ module Pheme
       parsed_content
     end
 
-    def parse_timestamp(queue_message)
+    def parse_metadata(queue_message)
       message_body = JSON.parse(queue_message.body)
-      message_body['Timestamp']
+      { timestamp: message_body['Timestamp'] }
     end
 
     def get_metadata(message_body)
@@ -97,7 +97,7 @@ module Pheme
       RecursiveOpenStruct.new({ wrapper: parsed_body }, recurse_over_arrays: true).wrapper
     end
 
-    def handle(_message, _timestamp)
+    def handle(_message, _metadata)
       raise NotImplementedError
     end
 

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = "0.0.12".freeze
+  VERSION = "1.0.0".freeze
 end

--- a/spec/message_handler_spec.rb
+++ b/spec/message_handler_spec.rb
@@ -1,7 +1,8 @@
 describe Pheme::MessageHandler do
   before(:each) { use_default_configuration! }
   let(:message) { RecursiveOpenStruct.new(status: "complete") }
-  subject { ExampleMessageHandler.new(message: message) }
+  let(:timestamp) { '2018-04-17T21:45:05.915Z' }
+  subject { ExampleMessageHandler.new(message: message, timestamp: timestamp) }
 
   describe "#handle" do
     it "handles the message correctly" do

--- a/spec/message_handler_spec.rb
+++ b/spec/message_handler_spec.rb
@@ -2,7 +2,7 @@ describe Pheme::MessageHandler do
   before(:each) { use_default_configuration! }
   let(:message) { RecursiveOpenStruct.new(status: "complete") }
   let(:timestamp) { '2018-04-17T21:45:05.915Z' }
-  subject { ExampleMessageHandler.new(message: message, timestamp: timestamp) }
+  subject { ExampleMessageHandler.new(message: message, metadata: { timestamp: timestamp }) }
 
   describe "#handle" do
     it "handles the message correctly" do

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -172,7 +172,7 @@ describe Pheme::QueuePoller do
       end
 
       it "handles the message" do
-        expect(ExampleMessageHandler).to receive(:new).with(message: RecursiveOpenStruct.new(message), timestamp: timestamp)
+        expect(ExampleMessageHandler).to receive(:new).with(message: RecursiveOpenStruct.new(message), metadata: { timestamp: timestamp })
         subject.poll
       end
 

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -1,5 +1,6 @@
 describe Pheme::QueuePoller do
   let(:queue_url) { "https://sqs.us-east-1.amazonaws.com/whatever" }
+  let(:timestamp) { '2018-04-17T21:45:05.915Z' }
 
   describe ".new" do
     context "when initialized with valid params" do
@@ -104,7 +105,7 @@ describe Pheme::QueuePoller do
       let(:mock_connection_pool) { double }
       subject { ExampleQueuePoller.new(queue_url: queue_url, connection_pool_block: true) }
       let(:message) { { status: 'complete' } }
-      let(:notification) { { 'MessageId' => SecureRandom.uuid, 'Message' => message.to_json, 'Type' => 'Notification' } }
+      let(:notification) { { 'MessageId' => SecureRandom.uuid, 'Message' => message.to_json, 'Type' => 'Notification', 'Timestamp' => timestamp, } }
       let!(:queue_message) do
         OpenStruct.new(
           body: notification.to_json,
@@ -128,7 +129,7 @@ describe Pheme::QueuePoller do
     context "without connection pool block" do
       subject { ExampleQueuePoller.new(queue_url: queue_url) }
       let(:message) { { status: 'complete' } }
-      let(:notification) { { 'MessageId' => SecureRandom.uuid, 'Message' => message.to_json, 'Type' => 'Notification' } }
+      let(:notification) { { 'MessageId' => SecureRandom.uuid, 'Message' => message.to_json, 'Type' => 'Notification', 'Timestamp' => timestamp, } }
       let!(:queue_message) do
         OpenStruct.new(
           body: notification.to_json,
@@ -155,6 +156,7 @@ describe Pheme::QueuePoller do
           'MessageId' => SecureRandom.uuid,
           'Message' => message.to_json,
           'Type' => 'Notification',
+          'Timestamp' => timestamp,
         }
       end
       let!(:queue_message) do
@@ -170,7 +172,7 @@ describe Pheme::QueuePoller do
       end
 
       it "handles the message" do
-        expect(ExampleMessageHandler).to receive(:new).with(message: RecursiveOpenStruct.new(message))
+        expect(ExampleMessageHandler).to receive(:new).with(message: RecursiveOpenStruct.new(message), timestamp: timestamp)
         subject.poll
       end
 
@@ -188,6 +190,7 @@ describe Pheme::QueuePoller do
           'MessageId' => SecureRandom.uuid,
           'Message' => message.to_json,
           'Type' => 'Notification',
+          'Timestamp' => timestamp,
         }
       end
       let!(:queue_message) do

--- a/spec/support/example_queue_poller.rb
+++ b/spec/support/example_queue_poller.rb
@@ -3,10 +3,10 @@ class ExampleQueuePoller < Pheme::QueuePoller
     super(queue_url: queue_url, **kwargs)
   end
 
-  def handle(message, timestamp)
+  def handle(message, metadata)
     case message.status
     when 'complete', 'rejected'
-      ExampleMessageHandler.new(message: message, timestamp: timestamp).handle
+      ExampleMessageHandler.new(message: message, metadata: metadata).handle
     else
       raise ArgumentError, "Unknown message status: #{message.status}"
     end

--- a/spec/support/example_queue_poller.rb
+++ b/spec/support/example_queue_poller.rb
@@ -3,10 +3,10 @@ class ExampleQueuePoller < Pheme::QueuePoller
     super(queue_url: queue_url, **kwargs)
   end
 
-  def handle(message)
+  def handle(message, timestamp)
     case message.status
     when 'complete', 'rejected'
-      ExampleMessageHandler.new(message: message).handle
+      ExampleMessageHandler.new(message: message, timestamp: timestamp).handle
     else
       raise ArgumentError, "Unknown message status: #{message.status}"
     end


### PR DESCRIPTION
Exposes the timestamp to the handler so it can optionally decide to process or disregard a message based on last processes timestamp.