### PR TITLE
Add GZip compression to Pheme

### DIFF
--- a/lib/pheme/compression.rb
+++ b/lib/pheme/compression.rb
@@ -1,0 +1,27 @@
+require 'base64'
+require 'zlib'
+
+module Pheme
+  module Compression
+    def compress(body)
+      gz = Zlib::GzipWriter.new(StringIO.new)
+      gz << body
+      Base64.encode64(gz.close.string)
+    end
+
+    def decompress(body)
+      return Zlib::GzipReader.new(StringIO.new(Base64.decode64(body))).read if gzip?(body)
+      body
+    end
+
+    private
+
+    # https://tools.ietf.org/html/rfc1952#page-6
+    GZIP_MAGIC_NUMBER = "\037\213".unpack('n').freeze
+
+    def gzip?(body)
+      # Decode the first 4 bytes to compare with magic number
+      Base64.decode64(body[0..4]).unpack('n') == GZIP_MAGIC_NUMBER
+    end
+  end
+end

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -1,5 +1,9 @@
+require_relative 'compression'
+
 module Pheme
   class QueuePoller
+    include Compression
+
     attr_accessor :queue_url, :queue_poller, :connection_pool_block, :format, :max_messages, :poller_configuration
 
     def initialize(queue_url:, connection_pool_block: false, max_messages: nil, format: :json, poller_configuration: {}, sqs_client: nil)
@@ -84,7 +88,7 @@ module Pheme
     end
 
     def get_content(body)
-      body['Message']
+      decompress(body['Message'])
     end
 
     def parse_csv(message_contents)

--- a/lib/pheme/topic_publisher.rb
+++ b/lib/pheme/topic_publisher.rb
@@ -1,5 +1,20 @@
+require_relative 'compression'
+
 module Pheme
   class TopicPublisher
+    include Compression
+
+    #
+    # Constant with message size limit.
+    # The message size also includes some metadata: 'name' and 'type'.
+    # We give ourselves a buffer for this metadata.
+    #
+    # Source: https://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html#SNSMessageAttributesNTV
+    #
+    SNS_SIZE_LIMIT = 262144
+    EXPECTED_METADATA_SIZE = 1024
+    MESSAGE_SIZE_LIMIT = SNS_SIZE_LIMIT - EXPECTED_METADATA_SIZE
+
     attr_accessor :topic_arn
 
     def initialize(topic_arn:)
@@ -23,8 +38,11 @@ module Pheme
     end
 
     def serialize(message)
-      return message if message.is_a? String
-      message.to_json
+      message = message.to_json unless message.is_a? String
+
+      return compress(message) if message.bytesize > MESSAGE_SIZE_LIMIT
+
+      message
     end
   end
 end

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -90,6 +90,17 @@ describe Pheme::QueuePoller do
         expect(subject.first.first.test).to eq('test')
       end
     end
+
+    context "with compressed body" do
+      let(:format) { :json }
+      let(:message) do
+        gz = Zlib::GzipWriter.new(StringIO.new)
+        gz << { test: 'test' }.to_json
+        Base64.encode64(gz.close.string)
+      end
+
+      its([:test]) { is_expected.to eq('test') }
+    end
   end
 
   describe "#poll" do


### PR DESCRIPTION
Compresses and decompresses payloads larger than the current AWS SNS limit of 256K.