### PR TITLE
reduce aws-sdk-dependencies

### DIFF
--- a/lib/pheme.rb
+++ b/lib/pheme.rb
@@ -1,6 +1,7 @@
 require 'active_support/all'
 require 'recursive-open-struct'
-require 'aws-sdk'
+require 'aws-sdk-sns'
+require 'aws-sdk-sqs'
 require 'securerandom'
 require 'smarter_csv'
 

--- a/pheme.gemspec
+++ b/pheme.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.1.0"
 
   gem.add_dependency "activesupport", ">= 4"
-  gem.add_dependency "aws-sdk", ">= 2", "< 4"
+  gem.add_dependency "aws-sdk-sns", "~> 1.1"
+  gem.add_dependency "aws-sdk-sqs", "~> 1.3"
   gem.add_dependency "recursive-open-struct", "~> 1"
   gem.add_dependency "smarter_csv", "~> 1"
 


### PR DESCRIPTION
aws-sdk pulls in well over a 100 gems. This switches us over to require only the dependencies we need.

This makes the minimum version requirement ~> 3. The interface for v2 and v3 gems is identical, so services should be able to update if needed by simply updating their Gemfile: https://github.com/aws/aws-sdk-ruby/blob/master/V3_UPGRADING_GUIDE.md