### PR TITLE
allow setting a topic_arn using a class setter

### DIFF
--- a/lib/pheme/topic_publisher.rb
+++ b/lib/pheme/topic_publisher.rb
@@ -15,12 +15,19 @@ module Pheme
     EXPECTED_METADATA_SIZE = 1.kilobyte
     MESSAGE_SIZE_LIMIT = SNS_SIZE_LIMIT - EXPECTED_METADATA_SIZE
 
-    attr_accessor :topic_arn
+    class << self
+      attr_reader :_topic_arn
 
-    def initialize(topic_arn:)
+      def topic_arn(topic_arn)
+        @_topic_arn = topic_arn
+      end
+    end
+
+    def initialize(topic_arn: self.class._topic_arn)
       raise ArgumentError, "must specify non-nil topic_arn" unless topic_arn.present?
       @topic_arn = topic_arn
     end
+    attr_accessor :topic_arn
 
     def publish_events
       raise NotImplementedError

--- a/spec/support/example_with_arn_publisher.rb
+++ b/spec/support/example_with_arn_publisher.rb
@@ -1,0 +1,3 @@
+class ExampleWithArnPublisher < Pheme::TopicPublisher
+  topic_arn "arn:aws:sns:whatever"
+end

--- a/spec/topic_publisher_spec.rb
+++ b/spec/topic_publisher_spec.rb
@@ -13,6 +13,12 @@ describe Pheme::TopicPublisher do
         expect { ExamplePublisher.new(topic_arn: nil) }.to raise_error(ArgumentError)
       end
     end
+
+    context "when topic_arn set via class setter" do
+      it "does not raise an error" do
+        expect { ExampleWithArnPublisher.new }.not_to raise_error
+      end
+    end
   end
 
   describe "#publish_events" do


### PR DESCRIPTION
The topic_arn doesn't change for a publisher. Adds new interface to allow setting the arn via a setter method.

```
Class MyPublisher < Pheme:TopicPublisher
  topic_arn 'arn:example:123'
end
```