### PR TITLE
Make pheme logging quieter

### DIFF
--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -146,7 +146,7 @@ module Pheme
     end
 
     def log_delete(queue_message)
-      Pheme.logger.info({
+      Pheme.logger.debug({
         message: "#{self.class} deleted message #{queue_message.message_id}",
         message_id: queue_message.message_id,
         queue_poller: self.class.to_s,
@@ -155,7 +155,7 @@ module Pheme
     end
 
     def log_message_received(queue_message, body)
-      Pheme.logger.info({
+      Pheme.logger.debug({
         message: "#{self.class} received message #{queue_message.message_id}",
         queue_poller: self.class.to_s,
         message_id: queue_message.message_id,

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = "1.2.1".freeze
+  VERSION = "1.2.2".freeze
 end


### PR DESCRIPTION
I've noticed that we ship a _lot_ of datadog logs that are nothing more than "received message" and "deleted" message. At the very least it feels like `log_delete` should be debug level, since that action is more or less a known quantity, and doesn't include very much useful metadata.

I've also set `log_message_received` to debug level but maybe that's the wrong choice, since the received message does have some useful metadata about the message inside.

This PR is a proposal -- I don't know that this proposal is "correct" so let's get some opinions.