### PR TITLE
[WIP] add retries on EBADF errors for aws sdk calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0 - 2019-02-06
+### Added
+- retries on aws sdk calls for specific types of errors
+
 ## 2.0.1 - 2019-01-03
 ### Changed
 - add internal gem spec to test standard gem behavior, reduces unnecessary copy and pasting

--- a/lib/ws/pheme.rb
+++ b/lib/ws/pheme.rb
@@ -2,6 +2,7 @@ require 'active_support/all'
 require 'recursive-open-struct'
 require 'aws-sdk-sns'
 require 'aws-sdk-sqs'
+require 'retryable'
 require 'securerandom'
 require 'smarter_csv'
 

--- a/lib/ws/pheme/configuration.rb
+++ b/lib/ws/pheme/configuration.rb
@@ -22,6 +22,18 @@ module Ws::Pheme
     def initialize
       @logger ||= Logger.new(STDOUT)
       @logger = ActiveSupport::TaggedLogging.new(@logger) unless @logger.respond_to?(:tagged)
+      Retryable.configure do |config|
+        config.contexts[:sns] = {
+            on: [Errno::EBADF],
+            sleep: 1,
+            tries: 3,
+        }
+        config.contexts[:queue_poller] = {
+            on: [Errno::EBADF],
+            sleep: 1,
+            tries: 3,
+        }
+      end
     end
 
     def validate!

--- a/lib/ws/pheme/queue_poller.rb
+++ b/lib/ws/pheme/queue_poller.rb
@@ -39,7 +39,7 @@ module Ws::Pheme
               content = parse_body(queue_message)
               metadata = parse_metadata(queue_message)
               handle(content, metadata)
-              queue_poller.delete_message(queue_message)
+              Retryable.with_context(:queue_poller) { queue_poller.delete_message(queue_message) }
               log_delete(queue_message)
               @messages_processed += 1
             rescue SignalException

--- a/lib/ws/pheme/topic_publisher.rb
+++ b/lib/ws/pheme/topic_publisher.rb
@@ -42,7 +42,11 @@ module Ws::Pheme
         topic_arn: topic_arn,
       }
       Ws::Pheme.logger.info(payload.to_json)
-      Ws::Pheme.configuration.sns_client.publish(topic_arn: topic_arn, message: serialize(message))
+
+      serialized_message = serialize(message)
+      Retryable.with_context(:sns) do
+        Ws::Pheme.configuration.sns_client.publish(topic_arn: topic_arn, message: serialized_message)
+      end
     end
 
     def serialize(message)

--- a/lib/ws/pheme/version.rb
+++ b/lib/ws/pheme/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Pheme
-    VERSION = '2.0.2'.freeze
+    VERSION = '2.1.0'.freeze
   end
 end

--- a/ws-pheme.gemspec
+++ b/ws-pheme.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aws-sdk-sns", "~> 1.1"
   s.add_dependency "aws-sdk-sqs", "~> 1.3"
   s.add_dependency "recursive-open-struct", "~> 1"
+  s.add_dependency "retryable", "~> 3"
   s.add_dependency "smarter_csv", "~> 1"
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

the EBADF error is usually thrown at the kernel level to indicate socket disconnects (see https://stackoverflow.com/questions/53333075/aws-java-com-amazonaws-sdkclientexception-bad-file-descriptor). Add some retries as each try gets a new connection.