### PR TITLE
Release connection between handling messages

### DIFF
--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -63,18 +63,16 @@ module Pheme
             queue_poller.delete_message(queue_message)
             log_delete(queue_message)
             @messages_processed += 1
-          rescue SignalException, PG::UnableToSend
+          rescue SignalException
             throw :stop_polling
           rescue StandardError => e
-            if e.is_a?(PG::UnableToSend)
-
-              Pheme.logger.error(e)
-              Pheme.rollbar(e, "#{self.class} failed to process message", { message: content })
-            end
+            Pheme.logger.error(e)
+            Pheme.rollbar(e, "#{self.class} failed to process message", { message: content })
           end
         end
       end
       log_polling_end(time_start)
+    end
 
     # returns queue_message.body as hash,
     # stores and parses get_content to body[:content]

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.3.1'.freeze
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -25,7 +25,7 @@ describe Pheme do
     describe '.validate!' do
       subject { configuration.validate! }
 
-      let(:configuration) { Pheme::Configuration.new }
+      let(:configuration) { described_class.new }
 
       context 'empty configuration' do
         it 'is invalid when empty' do

--- a/spec/message_type/sns_message_spec.rb
+++ b/spec/message_type/sns_message_spec.rb
@@ -1,10 +1,4 @@
 describe Pheme::MessageType::SnsMessage do
-  module SnsMessage
-    class Fixture < ExampleQueuePoller
-      include Pheme::MessageType::SnsMessage
-    end
-  end
-
   subject { SnsMessage::Fixture.new }
 
   let(:poller) do
@@ -16,6 +10,12 @@ describe Pheme::MessageType::SnsMessage do
   end
 
   before do
+    test_class = Class.new(ExampleQueuePoller) do
+      include Pheme::MessageType::SnsMessage
+    end
+
+    stub_const('SnsMessage::Fixture', test_class)
+
     use_default_configuration!
     allow(Aws::SQS::QueuePoller).to receive(:new) { poller }
   end

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -201,11 +201,11 @@ describe Pheme::QueuePoller do
 
   describe "#poll" do
     before do
-      module ActiveRecord
-        class Base
-          def self.connection_pool; end
-        end
+      active_record_stub = Class.new do
+        def connection_pool; end
       end
+
+      stub_const('ActiveRecord::Base', active_record_stub)
     end
 
     context "with connection pool block" do


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
1. [Using the `connection_pool_block` option opens and holds a DB transaction open](https://github.com/wealthsimple/pheme/blob/master/lib/pheme/queue_poller.rb#L142) for the [entire duration of the poll](https://github.com/wealthsimple/pheme/blob/master/lib/pheme/queue_poller.rb#L56)
2. Sometimes the container that the poller is running on loses its database connection.
3. Pheme catches an error about the lost DB connection, logs it, and will continuously try to to `handle_content` with the broken DB connection (since the `with_optional_connection_pool_block` hasn't finished yet, and so its still using the same transaction as the one it first acquired, even if its broken).

This gets a container stuck until redeploying.
I think grabbing a new connection each time from the pool would get around this issue.


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Obtain a DB connection from the pool every time when trying to `handle_content`


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
