### PR TITLE
Added topic arn to queue_message metadata

### DIFF
--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -102,7 +102,7 @@ module Pheme
 
     def parse_metadata(queue_message)
       message_body = JSON.parse(queue_message.body)
-      { timestamp: message_body['Timestamp'] }
+      { timestamp: message_body['Timestamp'], topic_arn: message_body['TopicArn'] }
     end
 
     def get_metadata(message_body)

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '3.3.2'.freeze
+  VERSION = '3.3.3'.freeze
 end

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -183,6 +183,7 @@ describe Pheme::QueuePoller do
       it { is_expected.to be_a(Array) }
       its(:first) { is_expected.to be_a(Array) }
       its('first.first') { is_expected.to be_a(RecursiveOpenStruct) }
+
       it "parses the nested object" do
         expect(subject.first.first.test).to eq('test')
       end

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -2,6 +2,7 @@ describe Pheme::QueuePoller do
   let(:valid_queue_poller) { ExampleQueuePoller.new(queue_url: queue_url) }
   let(:queue_url) { "https://sqs.us-east-1.amazonaws.com/whatever" }
   let(:timestamp) { '2018-04-17T21:45:05.915Z' }
+  let(:topic_arn) { 'arn:topic:test' }
 
   let!(:queue_message) do
     OpenStruct.new(
@@ -214,7 +215,15 @@ describe Pheme::QueuePoller do
       let(:mock_connection_pool) { double }
 
       let(:message) { { status: 'complete' } }
-      let(:notification) { { 'MessageId' => SecureRandom.uuid, 'Message' => message.to_json, 'Type' => 'Notification', 'Timestamp' => timestamp } }
+      let(:notification) {
+        {
+          'MessageId' => SecureRandom.uuid,
+          'Message' => message.to_json,
+          'Type' => 'Notification',
+          'Timestamp' => timestamp,
+          'TopicArn' => topic_arn,
+        }
+      }
       let!(:queue_message) do
         OpenStruct.new(
           body: notification.to_json,
@@ -239,7 +248,15 @@ describe Pheme::QueuePoller do
       subject { ExampleQueuePoller.new(queue_url: queue_url) }
 
       let(:message) { { status: 'complete' } }
-      let(:notification) { { 'MessageId' => SecureRandom.uuid, 'Message' => message.to_json, 'Type' => 'Notification', 'Timestamp' => timestamp } }
+      let(:notification) {
+        {
+          'MessageId' => SecureRandom.uuid,
+          'Message' => message.to_json,
+          'Type' => 'Notification',
+          'Timestamp' => timestamp,
+          'TopicArn' => topic_arn,
+        }
+      }
       let!(:queue_message) do
         OpenStruct.new(
           body: notification.to_json,
@@ -268,6 +285,7 @@ describe Pheme::QueuePoller do
           'Message' => message.to_json,
           'Type' => 'Notification',
           'Timestamp' => timestamp,
+          'TopicArn' => topic_arn,
         }
       end
       let!(:queue_message) do
@@ -283,7 +301,10 @@ describe Pheme::QueuePoller do
       end
 
       it "handles the message" do
-        expect(ExampleMessageHandler).to receive(:new).with(message: RecursiveOpenStruct.new(message), metadata: { timestamp: timestamp })
+        expect(ExampleMessageHandler).to receive(:new).with(
+          message: RecursiveOpenStruct.new(message),
+          metadata: { timestamp: timestamp, topic_arn: topic_arn },
+        )
         subject.poll
       end
 


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

We have a queue that handles several different topics that then in our code branch to separate handlers. I would like to utilize the message metadata that we already have and expose the topic_arn to our queue handlers in our micro-services so we can detect which message we are consuming and act accordingly. 

#### What changed <!-- Summary of changes when modifying hundreds of lines -->



<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
