### PR TITLE
feat: add functionality to publish message attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.4.0 - 2020-03-17
+### Added
+- Add the ability to pass message attributes to SNS
+
 ## 3.3.0 - 2019-07-09
 ### Added
 - Add more friendly options for initializing queue pollers by either:

--- a/lib/pheme/topic_publisher.rb
+++ b/lib/pheme/topic_publisher.rb
@@ -34,7 +34,7 @@ module Pheme
       raise NotImplementedError
     end
 
-    def publish(message, sns_client: Pheme.configuration.sns_client)
+    def publish(message, sns_client: Pheme.configuration.sns_client, message_attributes: nil)
       payload = {
         message: "#{self.class} publishing message to #{topic_arn}",
         body: message,
@@ -42,7 +42,8 @@ module Pheme
         topic_arn: topic_arn,
       }
       Pheme.logger.info(payload.to_json)
-      sns_client.publish(topic_arn: topic_arn, message: serialize(message))
+
+      sns_client.publish(topic_arn: topic_arn, message: serialize(message), message_attributes: message_attributes)
     end
 
     def serialize(message)

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '3.3.3'.freeze
+  VERSION = '3.4.0'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,4 +35,4 @@ def use_default_configuration!
   end
 end
 
-Dir["./spec/support/**/*.rb"].each { |f| require f }
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }

--- a/spec/topic_publisher_spec.rb
+++ b/spec/topic_publisher_spec.rb
@@ -36,10 +36,12 @@ describe Pheme::TopicPublisher do
       expect(Pheme.configuration.sns_client).to receive(:publish).with({
         topic_arn: "arn:aws:sns:whatever",
         message: { id: "id-0", status: "complete" }.to_json,
+        message_attributes: nil,
       })
       expect(Pheme.configuration.sns_client).to receive(:publish).with({
         topic_arn: "arn:aws:sns:whatever",
         message: { id: "id-1", status: "complete" }.to_json,
+        message_attributes: nil,
       })
       subject.publish_events
     end
@@ -54,6 +56,7 @@ describe Pheme::TopicPublisher do
         expect(Pheme.configuration.sns_client).to receive(:publish).with({
           topic_arn: topic_arn,
           message: message,
+          message_attributes: nil,
         })
         subject.publish(message)
       end
@@ -65,6 +68,7 @@ describe Pheme::TopicPublisher do
           expect(sns_client).to receive(:publish).with({
             topic_arn: topic_arn,
             message: message,
+            message_attributes: nil,
           })
           subject.publish(message, sns_client: sns_client)
         end
@@ -89,6 +93,7 @@ describe Pheme::TopicPublisher do
             with({
               topic_arn: topic_arn,
               message: compressed_message,
+              message_attributes: nil,
             }),
         )
 


### PR DESCRIPTION
#### Why 

This will allow message attributes to be published along with a message. The message attributes are metadata so it should naturally be separate from the message itself.

https://docs.aws.amazon.com/sns/latest/dg/sns-tutorial-publish-message-with-attributes.html