### PR TITLE
receive message attributes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,3 @@ inherit_gem:
 AllCops:
   # Specify your target Ruby version here (only major/minor versions):
   TargetRubyVersion: 2.4
-
-Metrics/ClassLength: 
-  Max: 200
-
-Metrics/AbcSize:
-  Max: 24

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,9 @@ inherit_gem:
 AllCops:
   # Specify your target Ruby version here (only major/minor versions):
   TargetRubyVersion: 2.4
+
+Metrics/ClassLength: 
+  Max: 200
+
+Metrics/AbcSize:
+  Max: 24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0 - 2020-03-18
+### Breaking Changes
+- Add the ability for SQS to receive message attributes
+- `handle` function of `QueuePoller` now takes a third parameter `message_attributes`
+- blocks or `MessageHandler`s passed to `QueuePoller` can use this `message_attributes`
+
 ## 3.4.0 - 2020-03-17
 ### Added
 - Add the ability to pass message attributes to SNS

--- a/lib/pheme/message_handler.rb
+++ b/lib/pheme/message_handler.rb
@@ -1,10 +1,11 @@
 module Pheme
   class MessageHandler
-    attr_reader :message, :metadata, :timestamp
+    attr_reader :message, :metadata, :message_attributes, :timestamp
 
-    def initialize(message:, metadata: {})
+    def initialize(message:, metadata: {}, message_attributes: {})
       @message = message
       @metadata = metadata
+      @message_attributes = message_attributes
     end
 
     def handle

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -1,6 +1,7 @@
 require_relative 'compression'
 
 module Pheme
+  # rubocop:disable Metrics/ClassLength
   class QueuePoller
     include Compression
 
@@ -51,6 +52,7 @@ module Pheme
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
     def poll
       time_start = log_polling_start
       queue_poller.poll(poller_configuration) do |queue_message|
@@ -74,6 +76,7 @@ module Pheme
       end
       log_polling_end(time_start)
     end
+    # rubocop:enable Metrics/AbcSize
 
     # returns queue_message.body as hash,
     # stores and parses get_content to body[:content]
@@ -157,7 +160,7 @@ module Pheme
         value['binary_value']
       else
         Pheme.logger.info("Unsupported custom data type")
-        value["string_value"]
+        value["binary_value"] || value["string_value"]
       end
     end
 
@@ -218,4 +221,5 @@ module Pheme
       }.to_json)
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '3.4.0'.freeze
+  VERSION = '4.0.0'.freeze
 end

--- a/pheme.gemspec
+++ b/pheme.gemspec
@@ -29,8 +29,9 @@ Gem::Specification.new do |s|
   s.add_dependency "smarter_csv", "~> 1"
 
   s.add_development_dependency 'bundler'
-  s.add_development_dependency 'coveralls'
+  s.add_development_dependency 'coveralls', "~> 0.8"
   s.add_development_dependency 'git'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-collection_matchers'

--- a/pheme.gemspec
+++ b/pheme.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'coveralls', "~> 0.8"
   s.add_development_dependency 'git'
-  s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-collection_matchers'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'simplecov'
 require 'coveralls'
+require 'pry'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'simplecov'
 require 'coveralls'
-require 'pry'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,

--- a/spec/support/example_queue_poller.rb
+++ b/spec/support/example_queue_poller.rb
@@ -3,10 +3,10 @@ class ExampleQueuePoller < Pheme::QueuePoller
     super(queue_url: queue_url, **kwargs)
   end
 
-  def handle(message, metadata)
+  def handle(message, metadata, message_attributes)
     case message.status
     when 'complete', 'rejected'
-      ExampleMessageHandler.new(message: message, metadata: metadata).handle
+      ExampleMessageHandler.new(message: message, metadata: metadata, message_attributes: message_attributes).handle
     else
       raise ArgumentError, "Unknown message status: #{message.status}"
     end

--- a/spec/support/example_queue_poller_with_inlined_handler.rb
+++ b/spec/support/example_queue_poller_with_inlined_handler.rb
@@ -1,5 +1,6 @@
-Pheme::QueuePoller.new(queue_url: 'http://mock_url.test') do |message, metadata|
+Pheme::QueuePoller.new(queue_url: 'http://mock_url.test') do |message, metadata, message_attributes|
   # handle the message
   pp message
   pp metadata
+  pp message_attributes
 end


### PR DESCRIPTION
#### Why

With topic publisher able to add metadata in the form of `message_attributes`, it makes sense for the sqs poller to be able to retrieve the `message_attributes`.

This PR is a breaking change. It results in the `handle` method needing to take 3 parameters.