### PR TITLE
fix: retrieve message attributes from right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.1 - 2020-03-23
+### Fixes
+- Fixes 4.0.0. Instead of expecting message attributes in the message from `poll`, retrieves them from the right place.
+
 ## 4.0.0 - 2020-03-18
 ### Breaking Changes
 - Add the ability for SQS to receive message attributes

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -110,8 +110,9 @@ module Pheme
     end
 
     def parse_message_attributes(queue_message)
+      message_body = JSON.parse(queue_message.body)
       message_attributes = {}
-      queue_message.message_attributes&.each do |key, value|
+      message_body['MessageAttributes']&.each do |key, value|
         message_attributes[key.to_sym] = coerce_message_attribute(value)
       end
 
@@ -149,18 +150,18 @@ module Pheme
     private
 
     def coerce_message_attribute(value)
-      case value['data_type']
+      case value['Type']
       when 'String'
-        value['string_value']
+        value['Value']
       when 'Number'
-        JSON.parse(value['string_value'])
+        JSON.parse(value['Value'])
       when 'String.Array'
-        JSON.parse(value['string_value'])
+        JSON.parse(value['Value'])
       when 'Binary'
-        value['binary_value']
+        value['Value']
       else
         Pheme.logger.info("Unsupported custom data type")
-        value["binary_value"] || value["string_value"]
+        value["Value"]
       end
     end
 

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '4.0.0'.freeze
+  VERSION = '4.0.1'.freeze
 end

--- a/spec/queue_poller_spec.rb
+++ b/spec/queue_poller_spec.rb
@@ -146,14 +146,13 @@ describe Pheme::QueuePoller do
     context 'when message attributes' do
       let(:queue_message) do
         OpenStruct.new(
-          body: { Message: message }.to_json,
-          message_id: message_id,
-          message_attributes: {
-            "key" => {
-              "data_type" => data_type,
-              "string_value" => string_value,
+          body: {
+            Message: message,
+            MessageAttributes: {
+              key: { Type: data_type, Value: string_value },
             },
-          },
+          }.to_json,
+          message_id: message_id,
         )
       end
 


### PR DESCRIPTION
#### Why

I was originally expecting message_attributes from `message.message_attributes` as per this documentation:

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html#receive_message-instance_method

However the message had the below structure. Therefore we need to retrieve the message_attributes from the correct place.

```
 message_id="...",
 receipt_handle="...",
 md5_of_body="...",
 body= "..."
 attributes={"SenderId"=>"...", "ApproximateFirstReceiveTimestamp"=>"...", "ApproximateReceiveCount"=>"..", "SentTimestamp"=>".."},
 md5_of_message_attributes=nil,
 message_attributes={}
```

Within the body, the structure was:
```
{"Type"=>"...",
 "MessageId"=>"...",
 "TopicArn"=>"...",
 "Message"=> "...message here...",
 "Timestamp"=>"2020-03-23T17:34:04.874Z",
 "SignatureVersion"=>"1",
 "Signature"=> "..."
 "SigningCertURL"=>"...",
 "UnsubscribeURL"=> "...",
 "MessageAttributes"=>{"schema_version"=>{"Type"=>"Number", "Value"=>"1"}, "event_type"=>{"Type"=>"String", "Value"=>"employer-created"}}}
```
