### PR TITLE
Rename workflow files [skip ci]

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,8 +1,8 @@
 ---
-name: Pipeline
+name: Branches
 on:
   push:
-    branches:
+    branches-ignore:
       - master
 jobs:
   build:
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.DEVTOOLS_GITHUB_API_TOKEN }}
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -28,8 +26,3 @@ jobs:
         uses: wealthsimple/toolbox-script@v1
         with:
           script: await toolbox.ruby.test.run();
-      - name: Release
-        uses: wealthsimple/toolbox-script@v1
-        with:
-          script: await toolbox.ruby.publish.run();
-          nexus_gem_credentials_file: ${{ secrets.NEXUS_GEM_CREDENTIALS_FILE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 ---
-name: Pipeline
+name: Main
 on:
   push:
-    branches-ignore:
+    branches:
       - master
 jobs:
   build:
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.DEVTOOLS_GITHUB_API_TOKEN }}
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -26,3 +28,8 @@ jobs:
         uses: wealthsimple/toolbox-script@v1
         with:
           script: await toolbox.ruby.test.run();
+      - name: Release
+        uses: wealthsimple/toolbox-script@v1
+        with:
+          script: await toolbox.ruby.publish.run();
+          nexus_gem_credentials_file: ${{ secrets.NEXUS_GEM_CREDENTIALS_FILE }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pheme
+[![Github Actions Badge](https://github.com/wealthsimple/pheme/actions/workflows/main.yml/badge.svg)](https://github.com/wealthsimple/pheme/actions)
 
 [![GitHub Actions Workflow Badge](https://github.com/wealthsimple/pheme/actions/workflows/master-workflow.yml/badge.svg)](https://github.com/wealthsimple/pheme/actions)
 


### PR DESCRIPTION
#### Why
We have two workflows, so they should be named differently

#### What
- Use unique names for our different workflows
- Move CI badge to somewhere less likely to break parsing tools

> This pull request was generated automatically and might have some problems in it.
