### PR TITLE
Change default branch to "main"

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -3,7 +3,7 @@ name: Branches
 on:
   push:
     branches-ignore:
-      - master
+      - main
 jobs:
   build:
     name: Build
@@ -16,8 +16,8 @@ jobs:
         env:
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
           BUNDLE_NEXUS__IAD__W10EXTERNAL__COM: ${{ secrets.BUNDLE_NEXUS__IAD__W10EXTERNAL__COM }}
-      - name: Fetch master branch
-        run: git fetch origin master
+      - name: Fetch main branch
+        run: git fetch origin main
       - name: Lint
         uses: wealthsimple/toolbox-script@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Main
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     name: Build
@@ -18,8 +18,8 @@ jobs:
         env:
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
           BUNDLE_NEXUS__IAD__W10EXTERNAL__COM: ${{ secrets.BUNDLE_NEXUS__IAD__W10EXTERNAL__COM }}
-      - name: Fetch master branch
-        run: git fetch origin master
+      - name: Fetch main branch
+        run: git fetch origin main
       - name: Lint
         uses: wealthsimple/toolbox-script@v1
         with:

--- a/pheme.gemspec
+++ b/pheme.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.2'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'ws-style'
+  s.add_development_dependency 'ws-gem_publisher'
 end


### PR DESCRIPTION
#### What changed <!-- Summary of changes when modifying hundreds of lines -->
use `main` as default branch name instead of `master`.

Once approved, I will [rename the branch from `master` to `main` on GitHub](https://docs.github.com/en/github/administering-a-repository/renaming-a-branch) before merging.

#### Important

If you have checked out the repository locally before the default branch has been renamed, it will need to be updated like so:

```bash
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

for your convenience, consider putting these into a function in your shell configuration, so you can easily update any other repositories that get updated as well.

```bash
# ~/.bash_profile or ~/.zshrc
function git_migrate_to_main() {
  git branch -m master main
  git fetch origin
  git branch -u origin/main main
  git remote set-head origin -a
}
```


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->

> This pull request was generated automatically and might have some problems in it.  Reach out in [#developer-tools](https://wealthsimple.slack.com/archives/CD6A1K886) if something's gone wrong!
