### PR TITLE
Add cuncurrency to GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@
 name: Pipeline
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
#### Why

This adds a concurrency group to GitHub Actions workflows.

More info on what it is can be found [here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)
