### PR TITLE
Add support for SNS FIFO publish params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.1.0 - 2022-08-16
+### Changed
+- Added support for FIFO params when publishing to SNS topic
+
 ## 5.0.10 - 2022-08-12
 ### Changed
 - Updated dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pheme (5.0.10)
+    pheme (5.1.0)
       activesupport (>= 4)
       aws-sdk-sns (~> 1.1)
       aws-sdk-sqs (~> 1.3)
@@ -134,4 +134,4 @@ DEPENDENCIES
   ws-style
 
 BUNDLED WITH
-   2.3.16
+   2.3.14

--- a/lib/pheme/topic_publisher.rb
+++ b/lib/pheme/topic_publisher.rb
@@ -34,7 +34,11 @@ module Pheme
       raise NotImplementedError
     end
 
-    def publish(message, sns_client: Pheme.configuration.sns_client, message_attributes: nil)
+    def publish(message,
+                sns_client: Pheme.configuration.sns_client,
+                message_attributes: nil,
+                message_deduplication_id: nil,
+                message_group_id: nil)
       payload = {
         message: "#{self.class} publishing message to #{topic_arn}",
         body: message,
@@ -43,7 +47,13 @@ module Pheme
       }
       Pheme.logger.info(payload.to_json)
 
-      sns_client.publish(topic_arn: topic_arn, message: serialize(message), message_attributes: message_attributes)
+      sns_client.publish(
+        topic_arn: topic_arn,
+        message: serialize(message),
+        message_attributes: message_attributes,
+        message_deduplication_id: message_deduplication_id,
+        message_group_id: message_group_id,
+      )
     end
 
     def serialize(message)

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '5.0.10'.freeze
+  VERSION = '5.1.0'.freeze
 end

--- a/spec/topic_publisher_spec.rb
+++ b/spec/topic_publisher_spec.rb
@@ -37,11 +37,15 @@ describe Pheme::TopicPublisher do
         topic_arn: "arn:aws:sns:whatever",
         message: { id: "id-0", status: "complete" }.to_json,
         message_attributes: nil,
+        message_deduplication_id: nil,
+        message_group_id: nil,
       })
       expect(Pheme.configuration.sns_client).to receive(:publish).with({
         topic_arn: "arn:aws:sns:whatever",
         message: { id: "id-1", status: "complete" }.to_json,
         message_attributes: nil,
+        message_deduplication_id: nil,
+        message_group_id: nil,
       })
       subject.publish_events
     end
@@ -57,6 +61,8 @@ describe Pheme::TopicPublisher do
           topic_arn: topic_arn,
           message: message,
           message_attributes: nil,
+          message_deduplication_id: nil,
+          message_group_id: nil,
         })
         subject.publish(message)
       end
@@ -69,6 +75,8 @@ describe Pheme::TopicPublisher do
             topic_arn: topic_arn,
             message: message,
             message_attributes: nil,
+            message_deduplication_id: nil,
+            message_group_id: nil,
           })
           subject.publish(message, sns_client: sns_client)
         end
@@ -94,6 +102,8 @@ describe Pheme::TopicPublisher do
               topic_arn: topic_arn,
               message: compressed_message,
               message_attributes: nil,
+              message_deduplication_id: nil,
+              message_group_id: nil,
             }),
         )
 


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

Reference API doc: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SNS/Client.html#publish-instance_method
Reference FIFO SNS: https://aws.amazon.com/blogs/aws/introducing-amazon-sns-fifo-first-in-first-out-pub-sub-messaging/

If publishing to a FIFO SNS topic, need to be able to send in group and dedup params.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

Add ability to pass in params `message_deduplication_id` and `message_group_id`- pertinent for FIFO SNS publishing.

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
