### PR TITLE
chore: add changelog link to gemspec

### DIFF
--- a/pheme.gemspec
+++ b/pheme.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.summary = 'Ruby SNS publisher + SQS poller & message handler'
   s.homepage = 'https://github.com/wealthsimple/pheme'
 
+  s.metadata['changelog_uri'] = 'https://github.com/wealthsimple/pheme/blob/main/CHANGELOG.md'
+
   s.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.executables = s.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   s.require_paths = ['lib']


### PR DESCRIPTION
### Why

This will make it easier to keep dependencies up to date!

Depfu and Dependabot use the `changelog_uri` field to add a link to the changelog for this gem in dependency update PRs.

Related ticket: https://wealthsimple.atlassian.net/browse/BEPLAT-130

### What Changed

* Add `metadata.changelog_uri` field to the gemspec