### PR TITLE
chore: add changelog link to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.2.4 - 2023-07-26
+### Added
+- chore: add changelog link to gemspec
+
 
 ## 5.2.3 - 2023-07-17
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pheme (5.2.3)
+    pheme (5.2.4)
       activesupport (>= 4)
       aws-sdk-sns (~> 1.1)
       aws-sdk-sqs (~> 1.3)

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '5.2.3'.freeze
+  VERSION = '5.2.4'.freeze
 end

--- a/pheme.gemspec
+++ b/pheme.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.description = 'Ruby AWS SNS publisher + SQS poller & message handler'
   s.summary = 'Ruby SNS publisher + SQS poller & message handler'
   s.homepage = 'https://github.com/wealthsimple/pheme'
+  s.metadata['changelog_uri'] = 'https://github.com/wealthsimple/pheme/blob/main/CHANGELOG.md'
 
   s.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.executables = s.files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
### Why

This will make it easier to keep dependencies up to date!

Depfu and Dependabot use the `changelog_uri` field to add a link to the changelog for this gem in dependency update PRs.

Related ticket: https://wealthsimple.atlassian.net/browse/BEPLAT-130

### What Changed

* Add `metadata.changelog_uri` field to the gemspec

⚠ **This PR was opened automatically** ⚠ please reach out to #developer-tools on Slack if you have any questions!
