### PR TITLE
added ability to override visibility_timeout (default 30 seconds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 5.2.12 - 2023-01-02
+## 5.2.12 - 2024-01-03
+### Changed
+- Added ability to override **visibility_timeout** for QueuePoller
+
+## 5.2.12 - 2024-01-02
 ### Changed
 - Updated dependencies
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pheme (5.2.12)
+    pheme (5.2.13)
       activesupport (>= 4)
       aws-sdk-sns (~> 1.1)
       aws-sdk-sqs (~> 1.3)

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -34,7 +34,6 @@ module Pheme
       }.merge(poller_configuration || {})
 
       @poller_configuration[:idle_timeout] = idle_timeout unless idle_timeout.nil?
-
       @poller_configuration[:visibility_timeout] = visibility_timeout unless visibility_timeout.nil?
 
       if message_handler

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -34,6 +34,7 @@ module Pheme
       }.merge(poller_configuration || {})
 
       @poller_configuration[:idle_timeout] = idle_timeout unless idle_timeout.nil?
+
       @poller_configuration[:visibility_timeout] = visibility_timeout unless visibility_timeout.nil?
 
       if message_handler

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -29,7 +29,7 @@ module Pheme
       @poller_configuration = {
         wait_time_seconds: 10, # amount of time a long polling receive call can wait for a message before receiving a empty response (which will trigger another polling request)
         idle_timeout: 20, # disconnects poller after 20 seconds of idle time
-        visibility_timeout: 30, # amount of time to process and delete the message before it is added back into the queue
+        visibility_timeout: nil, # amount of time to process and delete the message before it is added back into the queue
         skip_delete: true, # manually delete messages
       }.merge(poller_configuration || {})
 

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -34,7 +34,7 @@ module Pheme
       }.merge(poller_configuration || {})
 
       @poller_configuration[:idle_timeout] = idle_timeout unless idle_timeout.nil?
-      @poller_configuration[:visibility_timeout] = visibility_timeout unless visibility_timeout.nil?
+      @poller_configuration[:visibility_timeout] = visibility_timeout
 
       if message_handler
         if message_handler.ancestors.include?(Pheme::MessageHandler)

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -14,6 +14,7 @@ module Pheme
       poller_configuration: {},
       sqs_client: nil,
       idle_timeout: nil,
+      visibility_timeout: nil,
       message_handler: nil,
       &block_message_handler)
       raise ArgumentError, "must specify non-nil queue_url" if queue_url.blank?
@@ -28,10 +29,12 @@ module Pheme
       @poller_configuration = {
         wait_time_seconds: 10, # amount of time a long polling receive call can wait for a message before receiving a empty response (which will trigger another polling request)
         idle_timeout: 20, # disconnects poller after 20 seconds of idle time
+        visibility_timeout: 30, # amount of time to process and delete the message before it is added back into the queue
         skip_delete: true, # manually delete messages
       }.merge(poller_configuration || {})
 
       @poller_configuration[:idle_timeout] = idle_timeout unless idle_timeout.nil?
+      @poller_configuration[:visibility_timeout] = visibility_timeout unless visibility_timeout.nil?
 
       if message_handler
         if message_handler.ancestors.include?(Pheme::MessageHandler)

--- a/lib/pheme/queue_poller.rb
+++ b/lib/pheme/queue_poller.rb
@@ -29,7 +29,7 @@ module Pheme
       @poller_configuration = {
         wait_time_seconds: 10, # amount of time a long polling receive call can wait for a message before receiving a empty response (which will trigger another polling request)
         idle_timeout: 20, # disconnects poller after 20 seconds of idle time
-        visibility_timeout: nil, # amount of time to process and delete the message before it is added back into the queue
+        visibility_timeout: nil, # amount of time in seconds to process and delete the message before it is added back into the queue
         skip_delete: true, # manually delete messages
       }.merge(poller_configuration || {})
 

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '5.2.12'.freeze
+  VERSION = '5.2.13'.freeze
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
We are seeing a large increase in transactions per batch in `poseidon` and need a way to increase the `visibility_timeout`, the default 30 seconds is not enough. Followed the AWS [documentation](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SQS/QueuePoller.html) on `visibility_timeout`.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Added ability to override the `visibility_timeout` from 30 seconds.


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
