### PR TITLE
Do Not Log Message Body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.2.14 - 2024-02-05
+### Changed
+- Do not log message body when publishing. Message bodies may have PII like email addresses in them.
+
 ## 5.2.13 - 2024-01-26
 ### Changed
 - Updated dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pheme (5.2.13)
+    pheme (5.2.14)
       activesupport (>= 4)
       aws-sdk-sns (~> 1.1)
       aws-sdk-sqs (~> 1.3)

--- a/lib/pheme/topic_publisher.rb
+++ b/lib/pheme/topic_publisher.rb
@@ -45,7 +45,8 @@ module Pheme
         publisher: self.class.to_s,
         topic_arn: topic_arn,
       }
-      Pheme.logger.info(payload.to_json)
+
+      Pheme.logger.info(payload.except(:body).to_json)
 
       sns_client.publish(
         topic_arn: topic_arn,

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '5.2.13'.freeze
+  VERSION = '5.2.14'.freeze
 end

--- a/spec/topic_publisher_spec.rb
+++ b/spec/topic_publisher_spec.rb
@@ -47,6 +47,15 @@ describe Pheme::TopicPublisher do
         message_deduplication_id: nil,
         message_group_id: nil,
       })
+      expect(Pheme.logger).to(
+        receive(:info).with(
+          {
+            message: "ExamplePublisher publishing message to arn:aws:sns:whatever",
+            publisher: "ExamplePublisher",
+            topic_arn: "arn:aws:sns:whatever",
+          }.to_json,
+        ).twice,
+      )
       subject.publish_events
     end
 
@@ -64,6 +73,15 @@ describe Pheme::TopicPublisher do
           message_deduplication_id: nil,
           message_group_id: nil,
         })
+        expect(Pheme.logger).to(
+          receive(:info).with(
+            {
+              message: "Pheme::TopicPublisher publishing message to #{topic_arn}",
+              publisher: "Pheme::TopicPublisher",
+              topic_arn: topic_arn,
+            }.to_json,
+          ),
+        )
         subject.publish(message)
       end
 
@@ -78,6 +96,15 @@ describe Pheme::TopicPublisher do
             message_deduplication_id: nil,
             message_group_id: nil,
           })
+          expect(Pheme.logger).to(
+            receive(:info).with(
+              {
+                message: "Pheme::TopicPublisher publishing message to #{topic_arn}",
+                publisher: "Pheme::TopicPublisher",
+                topic_arn: topic_arn,
+              }.to_json,
+            ),
+          )
           subject.publish(message, sns_client: sns_client)
         end
       end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
We were logging the message body, which could contain PII. In API, this contains user email addresses.


#### What changed <!-- Summary of changes when modifying hundreds of lines -->

In response to an incident, we are no longer logging the message body when publishing. 

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
