### PR TITLE
chore(docs): update readme for correct use of error reporting func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.0.2 - 2025-02-13
+### Changed
+- Update docs
+
 ## 6.0.1 - 2025-02-13
 ### Changed
 - Updated dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pheme (6.0.1)
+    pheme (6.0.2)
       activesupport (>= 4)
       aws-sdk-sns (~> 1.1)
       aws-sdk-sqs (~> 1.3)

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Pheme.configure do |config|
   config.logger = Logger.new(STDOUT) # Optionally replace with your app logger, e.g. `Rails.logger`
   
   # Internal wealthsimple error handler
-  config.error_reporting_func = Ws::Railway::ErrorReporting.capture_exception
+  config.error_reporting_func = Ws::Railway::ErrorReporting.method(:capture_exception)
   # Sentry
-  config.error_reporting_func = Sentry.capture_exception
+  config.error_reporting_func = Sentry.method(:capture_exception)
   # Rollbar
-  config.error_reporting_func = Rollbar.error
+  config.error_reporting_func = Rollbar.method(:error)
 end
 ```
 

--- a/lib/pheme/version.rb
+++ b/lib/pheme/version.rb
@@ -1,3 +1,3 @@
 module Pheme
-  VERSION = '6.0.1'.freeze
+  VERSION = '6.0.2'.freeze
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

calling the error reporting function doesn't work, will need to pass the reference to the function.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

fix docs so the instructions do not cause silent failure